### PR TITLE
Tweak text removing "Don't want to"

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,9 +21,9 @@ function IndexPage() {
                   </span>
                 </h2>
                 <p className="mt-3 text-base text-gray-500 sm:mt-5 sm:text-xl lg:text-lg xl:text-xl">
-                  Don&apos;t have any active Ruby meetups near you? 
-                  Can&apos;t attend even if there are? We want to bring
-                  the joy of congregating with your Ruby friends to you with{" "}
+                  Don&apos;t have any active Ruby meetups near you? Can&apos;t
+                  attend even if there are? We want to bring the joy of
+                  congregating with your Ruby friends to you with{" "}
                   <strong>online Ruby meetups!</strong>
                 </p>
                 <p className="mt-3 text-base text-gray-500 sm:mt-5 sm:text-xl lg:text-lg xl:text-xl">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,8 +21,8 @@ function IndexPage() {
                   </span>
                 </h2>
                 <p className="mt-3 text-base text-gray-500 sm:mt-5 sm:text-xl lg:text-lg xl:text-xl">
-                  Don&apos;t have any active Ruby meetups near you? Don&apos;t
-                  want to, or can&apos;t, go even if there are? We want to bring
+                  Don&apos;t have any active Ruby meetups near you? 
+                  Can&apos;t attend even if there are? We want to bring
                   the joy of congregating with your Ruby friends to you with{" "}
                   <strong>online Ruby meetups!</strong>
                 </p>


### PR DESCRIPTION
## Prerequisites checklist

- [x] I have read the [contributing guidelines](https://github.com/andrewmcodes/ruby-meetup-online/blob/master/CONTRIBUTING.md).

## What is the purpose of this pull request?

[x] Documentation update
[ ] Bug fix
[ ] New feature
[ ] Other, please explain:

## What changes did you make? (Give an overview)

Changed the text on the home page to remove "Don't want to attend".

## Is there anything you'd like reviewers to focus on?

This is a cool idea. It kicked off a lively discussion in our Slack group organizing the Bangkok.rb ruby meetup about offline vs online meetups. We don't want to discourage people from attending in-person meetups, so we think it good to emphasise people who *cannot* attend (e.g. no meetup in city, times of IRL meetup is inconvenient) rather than those who *do not want* to attend (it's intimidating, i'm scared of coronavirus) - it's tough enough to get people to attend as it is :) Let this not be seen as a criticism of the idea itself which i think is excellent!

## Screenshots
